### PR TITLE
Refocus mining script on RSG with shiny ore workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,98 +1,53 @@
 # jc-mining - Recreated
- A newly and better optimized mining system!
+A refreshed and optimised mining system focused on the RSG framework.
 
-# PolyZone
-Add the polyzone script in a folder for itself, that's a resource for itself and not part of the script, however I have realised that a lot of the polyzones are different to this one that is compatible!
+## PolyZone
+Add the PolyZone script as its own resource – it is required for the mining zones to function correctly.
 
-# Showcase:
-https://youtu.be/bixu5KhiE-4
+## Showcase
+https://youtu.be/bixu5KhiE-4  
 https://youtu.be/FLDydwk9LX0
 
-# JC-Mining
-JC-Mining is a more advanced mining script created with capability for both RSG and VORP now too! It involves a very easy and well configurable config mine, including bunch of other features listed below, video showcases above, and as always discord for support too below!
+## Features
+- Configurable mining that only produces `rock` plus a chance to uncover `shinyore` dirty stones.
+- Pickaxe durability stored in item metadata (default 100, -1 per swing) with automatic replacement when broken.
+- Ice drill durability (default 100, -3 per use) with an ox_target interaction and interact-sound drilling audio.
+- Washing system that requires the player to stand in water, shows a countdown, and converts each shiny ore into a gem based on weighted probabilities (1 stone = 1 gem).
+- Simple configuration for rock yields, shiny ore chances, washing duration, gem table and drill rewards.
 
-# Features
-- Rock Washing
-- Several mine locations
-- Hidden Mines
-- Multiple mine reward tables
-- Configurable pickaxe durability with replacement item support
-- Ice drilling using placed drill press props
+## Dependencies
+- [rsg-core](https://github.com/)
+- [ox_lib](https://overextended.dev/)
+- [ox_target](https://overextended.dev/)
+- [PolyZone](https://github.com/mkafrin/PolyZone)
+- [interact-sound](https://github.com/qbcore-framework/interact-sound)
 
-# Dependencies
-***For RSG***
-- rsg-core
-- PolyZone
+Add a drilling `.ogg` clip of your choice to `interact-sound/client/html/sounds/`, register it with that resource's manifest, and keep the filename aligned with `Config.Drill.soundName`.
 
-***For Vorp***
-- vorp-core
-- vorp_progressbar
-- PolyZone
+## Adding Items (rsg-core)
+Below is a minimal item list needed for the new workflow. Adjust weights and images to fit your inventory setup.
 
-# Discord Support
-[https://discord.gg/xvU7HxsENH](https://discord.gg/uFVYG6UJaM)
+```lua
+-- Mining and washing
+['rock']      = { name = 'rock',      label = 'Rock',               weight = 100, type = 'item', image = 'rock.png',      unique = false, useable = false, shouldClose = false, description = 'A chunk of stone fresh from the mine.' },
+['shinyore']  = { name = 'shinyore',  label = 'Zabrudzony kamień',  weight = 250, type = 'item', image = 'shinyore.png',  unique = false, useable = true,  shouldClose = true,  description = 'Kryje w sobie coś wartościowego… albo i nie.' },
 
-# Adding Items
-Wanna use the items I do? Make sure you have these in your items.lua for rsg-core(VORP is below)
-```-- Crafting aterials
-    ['iron']      = {['name'] = 'iron',      ['label'] = 'Iron',       ['weight'] = 1, ['type'] = 'item', ['image'] = 'iron.png',      ['unique'] = true, ['useable'] = true, ['shouldClose'] = true, ['combinable'] = nil, ['level'] = 0, ['description'] = 'A material used to craft with!'},
-    ['aluminum']      = {['name'] = 'aluminum',      ['label'] = 'Aluminum',       ['weight'] = 1, ['type'] = 'item', ['image'] = 'aluminum.png',      ['unique'] = true, ['useable'] = true, ['shouldClose'] = true, ['combinable'] = nil, ['level'] = 0, ['description'] = 'A material used to craft with!'},
-    ['coal']      = {['name'] = 'coal',      ['label'] = 'Coal',       ['weight'] = 1, ['type'] = 'item', ['image'] = 'coal.png',      ['unique'] = true, ['useable'] = true, ['shouldClose'] = true, ['combinable'] = nil, ['level'] = 0, ['description'] = 'A material used to craft with!'},
-    ['copper']      = {['name'] = 'copper',      ['label'] = 'Copper',       ['weight'] = 1, ['type'] = 'item', ['image'] = 'copper.png',      ['unique'] = true, ['useable'] = true, ['shouldClose'] = true, ['combinable'] = nil, ['level'] = 0, ['description'] = 'A material used to craft with!'},
-    ['silver']      = {['name'] = 'silver',      ['label'] = 'Silver',       ['weight'] = 1, ['type'] = 'item', ['image'] = 'silver.png',      ['unique'] = true, ['useable'] = true, ['shouldClose'] = true, ['combinable'] = nil, ['level'] = 0, ['description'] = 'A material used to craft with!'},
-    ['steel']      = {['name'] = 'steel',      ['label'] = 'Steel',       ['weight'] = 1, ['type'] = 'item', ['image'] = 'steel.png',      ['unique'] = true, ['useable'] = true, ['shouldClose'] = true, ['combinable'] = nil, ['level'] = 0, ['description'] = 'A material used to craft with!'},
-    ['lead']      = {['name'] = 'lead',      ['label'] = 'Lead',       ['weight'] = 1, ['type'] = 'item', ['image'] = 'lead.png',      ['unique'] = true, ['useable'] = true, ['shouldClose'] = true, ['combinable'] = nil, ['level'] = 0, ['description'] = 'A material used to craft with!'},
-    ['nitrate']      = {['name'] = 'nitrate',      ['label'] = 'Nitrate',       ['weight'] = 1, ['type'] = 'item', ['image'] = 'nitrate.png',      ['unique'] = true, ['useable'] = true, ['shouldClose'] = true, ['combinable'] = nil, ['level'] = 0, ['description'] = 'A material used to craft with!'},
-    ['fibers']      = {['name'] = 'fibers',      ['label'] = 'Fibers',       ['weight'] = 1, ['type'] = 'item', ['image'] = 'fibers.png',      ['unique'] = true, ['useable'] = true, ['shouldClose'] = true, ['combinable'] = nil, ['level'] = 0, ['description'] = 'A material used to craft with!'},
-    ['wood']      = {['name'] = 'wood',      ['label'] = 'Wood',       ['weight'] = 1, ['type'] = 'item', ['image'] = 'wood.png',      ['unique'] = true, ['useable'] = true, ['shouldClose'] = true, ['combinable'] = nil, ['level'] = 0, ['description'] = 'A material used to craft with!'},
-    ['woodlog']      = {['name'] = 'woodlog',      ['label'] = 'Wooden Log',       ['weight'] = 1, ['type'] = 'item', ['image'] = 'woodlog.png',      ['unique'] = true, ['useable'] = true, ['shouldClose'] = true, ['combinable'] = nil, ['level'] = 0, ['description'] = 'A material used to craft with!'},
-    ['woodplank']      = {['ame'] = 'woodplank',      ['label'] = 'Wooden Plank',       ['weight'] = 1, ['type'] = 'item', ['image'] = 'woodplank.png',      ['unique'] = true, ['useable'] = true, ['shouldClose'] = true, ['combinable'] = nil, ['level'] = 0, ['description'] = 'A material used to craft with!'},
-    ['wood']      = {['name'] = 'wood',      ['label'] = 'Wood',       ['weight'] = 1, ['type'] = 'item', ['image'] = 'wood.png',      ['unique'] = true, ['useable'] = true, ['shouldClose'] = true, ['combinable'] = nil, ['level'] = 0, ['description'] = 'A material used to craft with!'},
-    ['bark']      = {['name'] = 'bark',      ['label'] = 'Bark',       ['weight'] = 1, ['type'] = 'item', ['image'] = 'bark.png',      ['unique'] = true, ['useable'] = true, ['shouldClose'] = true, ['combinable'] = nil, ['level'] = 0, ['description'] = 'A material used to craft with!'},
-    ['rubber']      = {['name'] = 'rubber',      ['label'] = 'Rubber',       ['weight'] = 1, ['type'] = 'item', ['image'] = 'rubber.png',      ['unique'] = true, ['useable'] = true, ['shouldClose'] = true, ['combinable'] = nil, ['level'] = 0, ['description'] = 'A material used to craft with!'},
-    -- Oresn
-    ['ironore']      = {['name'] = 'ironore',      ['label'] = 'Iron Ore',       ['weight'] = 1, ['type'] = 'item', ['image'] = 'ironore.png',      ['unique'] = true, ['useable'] = true, ['shouldClose'] = true, ['combinable'] = nil, ['level'] = 0, ['description'] = 'A material used for smelting down!'},
-    ['unrefined_steel']      = {['name'] = 'unrefined_steel',      ['label'] = 'Unrefined Steel',       ['weight'] = 1, ['type'] = 'item', ['image'] = 'unrefined_steel.png',      ['unique'] = true, ['useable'] = true, ['shouldClose'] = true, ['combinable'] = nil, ['level'] = 0, ['description'] = 'A material used for smelting down!'},
-    ['aluminum_ore']      = {['name'] = 'aluminum_ore',      ['label'] = 'Aluminum Ore',       ['weight'] = 1, ['type'] = 'item', ['image'] = 'aluminum_ore.png',      ['unique'] = true, ['useable'] = true, ['shouldClose'] = true, ['combinable'] = nil, ['level'] = 0, ['description'] = 'A material used for smelting down!'},
-    ['copper_ore']      = {['name'] = 'copper_ore',      ['label'] = 'Copper Ore',       ['weight'] = 1, ['type'] = 'item', ['image'] = 'copper_ore.png',      ['unique'] = true, ['useable'] = true, ['shouldClose'] = true, ['combinable'] = nil, ['level'] = 0, ['description'] = 'A material used for smelting down!'},
-    ['gold_ore']      = {['name'] = 'gold_ore',      ['label'] = 'Gold Ore',       ['weight'] = 1, ['type'] = 'item', ['image'] = 'gold_ore.png',      ['unique'] = true, ['useable'] = true, ['shouldClose'] = true, ['combinable'] = nil, ['level'] = 0, ['description'] = 'A material used for smelting down!'},
-    ['emeraldore']      = {['name'] = 'emeraldore',      ['label'] = 'Emerald Ore',       ['weight'] = 1, ['type'] = 'item', ['image'] = 'emeraldore.png',      ['unique'] = true, ['useable'] = true, ['shouldClose'] = true, ['combinable'] = nil, ['level'] = 0, ['description'] = 'A material used for smelting down!'},
-    ['diamondore']      = {['name'] = 'diamondore',      ['label'] = 'Diamond Ore',       ['weight'] = 1, ['type'] = 'item', ['image'] = 'diamondore.png',      ['unique'] = true, ['useable'] = true, ['shouldClose'] = true, ['combinable'] = nil, ['level'] = 0, ['description'] = 'A material used for smelting down!'},
-    ['rubyore']      = {['name'] = 'rubyore',      ['label'] = 'Ruby Ore',       ['weight'] = 1, ['type'] = 'item', ['image'] = 'rubyore.png',      ['unique'] = true, ['useable'] = true, ['shouldClose'] = true, ['combinable'] = nil, ['level'] = 0, ['description'] = 'A material used for smelting down!'},
-    ['silver_ore']      = {['name'] = 'silver_ore',      ['label'] = 'Silver Ore',       ['weight'] = 1, ['type'] = 'item', ['image'] = 'silver_ore.png',      ['unique'] = true, ['useable'] = true, ['shouldClose'] = true, ['combinable'] = nil, ['level'] = 0, ['description'] = 'A material used for smelting down!'},
-    ['stone']      = {['name'] = 'stone',      ['label'] = 'Stone',       ['weight'] = 1, ['type'] = 'item', ['image'] = 'stone.png',      ['unique'] = true, ['useable'] = true, ['shouldClose'] = true, ['combinable'] = nil, ['level'] = 0, ['description'] = 'A material used for smelting down!'},
-    ['rock']      = {['name'] = 'rock',      ['label'] = 'Rock',       ['weight'] = 1, ['type'] = 'item', ['image'] = 'rock.png',      ['unique'] = true, ['useable'] = true, ['shouldClose'] = true, ['combinable'] = nil, ['level'] = 0, ['description'] = 'A material used for smelting down!'},
-    ['rocksalt']      = {['name'] = 'rocksalt',      ['label'] = 'Rocksalt',       ['weight'] = 1, ['type'] = 'item', ['image'] = 'rocksalt.png',      ['unique'] = true, ['useable'] = true, ['shouldClose'] = true, ['combinable'] = nil, ['level'] = 0, ['description'] = 'A material used for smelting down!'},
-    ['sand']      = {['name'] = 'sand',      ['label'] = 'Sand',       ['weight'] = 1, ['type'] = 'item', ['image'] = 'sand.png',      ['unique'] = true, ['useable'] = true, ['shouldClose'] = true, ['combinable'] = nil, ['level'] = 0, ['description'] = 'A material used for smelting down!'},
-    ['nitratepowder']      = {['name'] = 'nitratepowder',      ['label'] = 'Nitrate Powder',       ['weight'] = 1, ['type'] = 'item', ['image'] = 'nitratepowder.png',      ['unique'] = true, ['useable'] = true, ['shouldClose'] = true, ['combinable'] = nil, ['level'] = 0, ['description'] = 'A material used to craft with!'},
-    ['glass']      = {['name'] = 'glass',      ['label'] = 'Glass',       ['weight'] = 1, ['type'] = 'item', ['image'] = 'glass.png',      ['unique'] = true, ['useable'] = true, ['shouldClose'] = true, ['combinable'] = nil, ['level'] = 0, ['description'] = 'A material used to craft with!'},
-    -- Gems
-    ['diamond']      = {['name'] = 'diamond',      ['label'] = 'Diamond',       ['weight'] = 1, ['type'] = 'item', ['image'] = 'diamond.png',      ['unique'] = true, ['useable'] = true, ['shouldClose'] = true, ['combinable'] = nil, ['level'] = 0, ['description'] = 'A beautiful gem, often used to make jewelry with!'},
-    ['ruby']      = {['name'] = 'ruby',      ['label'] = 'Ruby',       ['weight'] = 1, ['type'] = 'item', ['image'] = 'ruby.png',      ['unique'] = true, ['useable'] = true, ['shouldClose'] = true, ['combinable'] = nil, ['level'] = 0, ['description'] = 'A beautiful gem, often used to make jewelry with!'},
-    ['emerald']      = {['name'] = 'emerald',      ['label'] = 'Emerald',       ['weight'] = 1, ['type'] = 'item', ['image'] = 'emerald.png',      ['unique'] = true, ['useable'] = true, ['shouldClose'] = true, ['combinable'] = nil, ['level'] = 0, ['description'] = 'A beautiful gem, often used to make jewelry with!'},
-    -- Gold
-    ['smallnugget']      = {['name'] = 'smallnugget',      ['label'] = 'Small Gold Nugget',       ['weight'] = 1, ['type'] = 'item', ['image'] = 'smallnugget.png',      ['unique'] = true, ['useable'] = true, ['shouldClose'] = true, ['combinable'] = nil, ['level'] = 0, ['description'] = 'Gold!'},
-    ['mediumnugget']      = {['name'] = 'mediumnugget',      ['label'] = 'Medium Gold Nugget',       ['weight'] = 1, ['type'] = 'item', ['image'] = 'mediumnugget.png',      ['unique'] = true, ['useable'] = true, ['shouldClose'] = true, ['combinable'] = nil, ['level'] = 0, ['description'] = 'Gold!'},
-    ['largenugget']      = {['name'] = 'largenugget',      ['label'] = 'Large Gold Nugget',       ['weight'] = 1, ['type'] = 'item', ['image'] = 'largenugget.png',      ['unique'] = true, ['useable'] = true, ['shouldClose'] = true, ['combinable'] = nil, ['level'] = 0, ['description'] = 'Gold!'},
-    ['goldflakes']      = {['name'] = 'goldflakes',      ['label'] = 'Gold Flakes',       ['weight'] = 1, ['type'] = 'item', ['image'] = 'goldflakes.png',      ['unique'] = true, ['useable'] = true, ['shouldClose'] = true, ['combinable'] = nil, ['level'] = 0, ['description'] = 'Gold!'},
-    
-    -- Tools
-    ['pickaxe']      = {['name'] = 'pickaxe',      ['label'] = 'Pickaxe',       ['weight'] = 1, ['type'] = 'item', ['image'] = 'pickaxe.png',      ['unique'] = true, ['useable'] = true, ['shouldClose'] = true, ['combinable'] = nil, ['level'] = 0, ['description'] = 'A tool used to mine with!'},
-    ['broken_pickaxe']      = {['name'] = 'broken_pickaxe',      ['label'] = 'Broken Pickaxe',       ['weight'] = 1, ['type'] = 'item', ['image'] = 'broken_pickaxe.png',      ['unique'] = true, ['useable'] = false, ['shouldClose'] = true, ['combinable'] = nil, ['level'] = 0, ['description'] = 'Remains of a shattered pickaxe.'},
-    ['ice']      = {['name'] = 'ice',      ['label'] = 'Ice Chunk',       ['weight'] = 1, ['type'] = 'item', ['image'] = 'ice.png',      ['unique'] = true, ['useable'] = true, ['shouldClose'] = true, ['combinable'] = nil, ['level'] = 0, ['description'] = 'Freshly drilled ice.'},
+-- Gems (sample table used by Config.Washing.gems)
+['diamond']     = { name = 'diamond',     label = 'Diamond',        weight = 100, type = 'item', image = 'diamond.png',     unique = false, useable = false, shouldClose = false, description = 'A beautiful gem used for fine jewellery.' },
+['ruby']        = { name = 'ruby',        label = 'Ruby',           weight = 100, type = 'item', image = 'ruby.png',        unique = false, useable = false, shouldClose = false, description = 'Deep red and very rare.' },
+['emerald']     = { name = 'emerald',     label = 'Emerald',        weight = 100, type = 'item', image = 'emerald.png',     unique = false, useable = false, shouldClose = false, description = 'A vibrant green gemstone.' },
+['sapphire']    = { name = 'sapphire',    label = 'Sapphire',       weight = 100, type = 'item', image = 'sapphire.png',    unique = false, useable = false, shouldClose = false, description = 'A rich blue gem.' },
+['opal']        = { name = 'opal',        label = 'Opal',           weight = 100, type = 'item', image = 'opal.png',        unique = false, useable = false, shouldClose = false, description = 'An iridescent stone with shifting colours.' },
+['topaz']       = { name = 'topaz',       label = 'Topaz',          weight = 100, type = 'item', image = 'topaz.png',       unique = false, useable = false, shouldClose = false, description = 'Golden and warm to the touch.' },
+['garnet']      = { name = 'garnet',      label = 'Garnet',         weight = 100, type = 'item', image = 'garnet.png',      unique = false, useable = false, shouldClose = false, description = 'A deep crimson crystal.' },
+['amethyst']    = { name = 'amethyst',    label = 'Amethyst',       weight = 100, type = 'item', image = 'amethyst.png',    unique = false, useable = false, shouldClose = false, description = 'A violet-hued gemstone.' },
+['jade']        = { name = 'jade',        label = 'Jade',           weight = 100, type = 'item', image = 'jade.png',        unique = false, useable = false, shouldClose = false, description = 'Smooth green stone prized in trade.' },
+['pearl']       = { name = 'pearl',       label = 'Pearl',          weight = 100, type = 'item', image = 'pearl.png',       unique = false, useable = false, shouldClose = false, description = 'Delicate treasure from the depths.' },
+
+-- Tools
+['pickaxe']          = { name = 'pickaxe',          label = 'Pickaxe',          weight = 100, type = 'item', image = 'pickaxe.png',      unique = true,  useable = true,  shouldClose = true,  description = 'Essential for breaking apart rock faces.' },
+['broken_pickaxe']   = { name = 'broken_pickaxe',   label = 'Broken Pickaxe',   weight = 100, type = 'item', image = 'broken_pickaxe.png', unique = false, useable = false, shouldClose = false, description = 'Remains of a shattered pickaxe.' },
+['ice']              = { name = 'ice',              label = 'Ice Chunk',        weight = 100, type = 'item', image = 'ice.png',          unique = false, useable = false, shouldClose = false, description = 'Freshly drilled ice.' }
 ```
 
-Items to add into database for VORP;
-```
-INSERT INTO items (item, label, `limit`, can_remove, type, usable, groupId, `desc`) VALUES 
-('diamondore', 'Diamond Ore', 30, 1, 'item_standard', 0, 1, 'A beautiful gem'),
-('rubyore', 'Ruby Ore', 30, 1, 'item_standard', 0, 1, 'A beautiful gem'),
-('emeraldore', 'Emerald Ore', 30, 1, 'item_standard', 0, 1, 'A beautiful gem'),
-('silver_ore', 'Silver Ore', 30, 1, 'item_standard', 0, 1, 'An ore that can be used to smelt down'),
-('gold_ore', 'Gold Ore', 30, 1, 'item_standard', 0, 1, 'An ore that can be used to smelt down'),
-('ironore', 'Iron Ore', 30, 1, 'item_standard', 0, 1, 'An ore that can be used to smelt down'),
-('aluminum_ore', 'Aluminum Ore', 30, 1, 'item_standard', 0, 1, 'An ore that can be used to smelt down'),
-('copper_ore', 'Copper Ore', 30, 1, 'item_standard', 0, 1, 'An ore that can be used to smelt down'),
-('rocksalt', 'Rocksalt', 30, 1, 'item_standard', 0, 1, 'Salt from a rock, can be used to caft with');
-```
-Remember also to make pickaxe and rock usable by changing their value from 0 to 1 in items table in your database!
+Update `Config.lua` to match your preferred chances, item names and sounds. Remember to make `shinyore` usable so players can start washing directly from their inventory.

--- a/config.lua
+++ b/config.lua
@@ -1,53 +1,52 @@
 Config = Config or {}
 
-Config.Framework = 'VORP' -- RSG or VORP
-
-Config.CommonChance = 80 -- Percentage of chance to get common items
-Config.GoldChance = 65 -- Percentage of chance to get Gold items
-Config.RareChance = 50 -- Percentage of chance to get Rare items
-Config.GemsChance = 35 -- Percentage of chance to get Gems items
-
 Config.Pickaxe = 'pickaxe' -- Pickaxe item name in the inventory
 Config.PickaxeProp = 'p_pickaxe01x' -- Pickaxe world prop that will be attached to the player
-Config.PickaxeDurability = 40 -- How many successful mining attempts a pickaxe can perform before breaking (set to 0 to disable)
+Config.PickaxeDurability = 100 -- How many successful mining attempts a pickaxe can perform before breaking (set to 0 to disable)
+Config.PickaxeDurabilityLoss = 1 -- Durability removed after every mining hit
 Config.PickaxeReplacementItem = 'broken_pickaxe' -- Item that will replace the pickaxe when it breaks (set to false/nil to disable)
 Config.PickaxeBrokenMessage = 'Your pickaxe broke!' -- Notification text when the pickaxe breaks
+
+Config.RockItem = 'rock' -- Base mining reward
+Config.RockRewardAmount = { min = 1, max = 3 } -- Amount of rocks rewarded per successful hit
+
+Config.ShinyOre = {
+    item = 'shinyore',
+    chancePerHit = 20, -- One in X chance to find a dirty shiny ore while mining (set to 0 to disable)
+    metadata = nil, -- Optional metadata table to attach to the item when rewarded
+    foundMessage = 'You have uncovered a dirty stone!'
+}
+
+Config.Washing = {
+    item = 'shinyore', -- Item that can be washed when using water
+    duration = 7000, -- Duration in milliseconds for washing a shiny ore
+    countdownLabel = 'Mycie kamienia: %ds', -- Text UI countdown while washing
+    gems = {
+        { item = 'diamond', chance = 5 },
+        { item = 'ruby', chance = 10 },
+        { item = 'emerald', chance = 10 },
+        { item = 'sapphire', chance = 10 },
+        { item = 'opal', chance = 15 },
+        { item = 'topaz', chance = 15 },
+        { item = 'garnet', chance = 10 },
+        { item = 'amethyst', chance = 10 },
+        { item = 'jade', chance = 10 },
+        { item = 'pearl', chance = 5 },
+    }
+}
 
 Config.IceDrill = {
     enabled = true, -- Toggle the ice drilling feature
     prop = 'p_drillpress01x', -- Prop that represents the drill press in the world
-    interactionDistance = 2.0, -- Distance required to interact with the drill
-    control = 0xCEFD9220, -- Default control (E) used to start drilling
-    prompt = 'Press [E] to drill for ice', -- Text UI prompt shown to players
+    targetIcon = 'fa-solid fa-icicles', -- Icon used by ox_target when interacting with the drill
+    prompt = 'Rozpocznij wiercenie lodu', -- Label used by ox_target
+    soundName = 'ice_drill', -- interact-sound clip played while drilling
     duration = 7000, -- Duration in milliseconds for a drilling cycle
     rewardItem = 'ice', -- Item that will be rewarded after drilling
     rewardAmount = { min = 1, max = 3 }, -- Amount of ice rewarded per cycle
-    durability = 30, -- How many times the drill can be used before breaking (set to 0 for infinite)
+    durability = 100, -- How many times the drill can be used before breaking (set to 0 for infinite)
+    durabilityLoss = 3, -- Durability removed every time the drill is used
     brokenMessage = 'The drill has been depleted and needs repairs.' -- Message shown when the drill breaks
-}
-
-Config.CommonItems = 'rock' -- The ordinary item you get from common mines!
-Config.GoldItems = 'gold_ore' -- Ordinary items you get from gold mines!
-Config.RareItems = { -- Items you get from rare mines
-    'diamondore',
-    'rubyore',
-    'silver_ore',
-    'gold_ore',
-    'coal',
-}
-Config.GemItems = { -- Items you get from gem mines
-    'diamondore',
-    'rubyore',
-    'emeraldore',
-    'coal',
-}
-Config.WashingItems = { -- Items you can get from washing rocks
-    'ironore',
-    'aluminum_ore',
-    'copper_ore',
-    'silver_ore',
-    'rocksalt',
-    'coal',
 }
 
 Config.Mines = {
@@ -56,7 +55,7 @@ Config.Mines = {
         id = 'grizzlies_mine', -- Unique Identifier
         blip = vector3(-1404.55, 1156.1407, 226.03324), -- The location of the blip
         showBlip = true, -- Whether the mine should be hidden or visible, true for visible false for hidden.
-        type = 'common', -- What kind of reward to get commonm = Config.CommonItems / rare = Config.RareItems / gold = Config.GoldItems / gems = Config.GemItems
+        type = 'common', -- Informational only (all mines use the rock + shiny ore reward table)
         coords = { -- Vector2 Polyzone coords 
             vector2(-1406.463256836, 1161.1862792968),
             vector2(-1419.1979980468, 1173.1785888672),

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -14,12 +14,11 @@ server_scripts {
 
 client_scripts {
     '@PolyZone/client.lua',
-	'@PolyZone/BoxZone.lua',
-	'@PolyZone/EntityZone.lua',
-	'@PolyZone/CircleZone.lua',
-	'@PolyZone/ComboZone.lua',
-    'client/rsg_main.lua',
-    'client/vorp_main.lua'
+        '@PolyZone/BoxZone.lua',
+        '@PolyZone/EntityZone.lua',
+        '@PolyZone/CircleZone.lua',
+        '@PolyZone/ComboZone.lua',
+    'client/rsg_main.lua'
 }
 
 --ui_page 'html/index.html'

--- a/server/rsg_main.lua
+++ b/server/rsg_main.lua
@@ -1,250 +1,388 @@
-if Config.Framework == 'RSG' then
-    local RSGCore = exports['rsg-core']:GetCoreObject()
-    local pickaxeDurability = {}
-    local drillDurability = {}
+local RSGCore = exports['rsg-core']:GetCoreObject()
+local drillDurability = {}
 
-    local function getPickaxeMaxDurability()
-        return Config.PickaxeDurability or 0
+local function cloneTable(tbl)
+    if not tbl then
+        return {}
     end
 
-    local function ensurePickaxeDurability(src)
-        local maxDurability = getPickaxeMaxDurability()
+    local copy = {}
 
-        if maxDurability <= 0 then
-            return
+    for k, v in pairs(tbl) do
+        copy[k] = v
+    end
+
+    return copy
+end
+
+local function formatDurability(current, max)
+    current = math.max(current, 0)
+    max = math.max(max, 0)
+    return string.format('Wytrzymałość: %d/%d', current, max)
+end
+
+local function updatePickaxeMetadata(Player, pickaxe, durability, maxDurability)
+    if not Player or not pickaxe then
+        return
+    end
+
+    local info = cloneTable(pickaxe.info)
+    info.durability = durability
+    info.maxDurability = maxDurability
+    info.meta = formatDurability(durability, maxDurability)
+
+    if Player.Functions.RemoveItem(Config.Pickaxe, 1, pickaxe.slot) then
+        Player.Functions.AddItem(Config.Pickaxe, 1, pickaxe.slot, info)
+    end
+end
+
+local function ensurePickaxeDurability(src)
+    local maxDurability = Config.PickaxeDurability or 0
+
+    if maxDurability <= 0 then
+        return
+    end
+
+    local Player = RSGCore.Functions.GetPlayer(src)
+
+    if not Player then
+        return
+    end
+
+    local pickaxe = Player.Functions.GetItemByName(Config.Pickaxe)
+
+    if not pickaxe then
+        return
+    end
+
+    local currentDurability = maxDurability
+
+    if pickaxe.info then
+        currentDurability = pickaxe.info.durability or maxDurability
+    end
+
+    if currentDurability > maxDurability then
+        currentDurability = maxDurability
+    end
+
+    local storedMax = pickaxe.info and pickaxe.info.maxDurability or maxDurability
+    local hasMeta = pickaxe.info and pickaxe.info.meta
+
+    if storedMax ~= maxDurability or not hasMeta or not pickaxe.info.durability then
+        updatePickaxeMetadata(Player, pickaxe, currentDurability, maxDurability)
+    end
+end
+
+local function handlePickaxeDurability(src)
+    local maxDurability = Config.PickaxeDurability or 0
+
+    if maxDurability <= 0 then
+        return
+    end
+
+    local Player = RSGCore.Functions.GetPlayer(src)
+
+    if not Player then
+        return
+    end
+
+    local pickaxe = Player.Functions.GetItemByName(Config.Pickaxe)
+
+    if not pickaxe then
+        return
+    end
+
+    local currentDurability = pickaxe.info and pickaxe.info.durability or maxDurability
+    local loss = Config.PickaxeDurabilityLoss or 1
+    local newDurability = currentDurability - loss
+
+    if newDurability <= 0 then
+        if Player.Functions.RemoveItem(Config.Pickaxe, 1, pickaxe.slot) then
+            local pickaxeItem = RSGCore.Shared.Items[Config.Pickaxe]
+
+            if pickaxeItem then
+                TriggerClientEvent('inventory:client:ItemBox', src, pickaxeItem, 'remove')
+            end
         end
 
-        if not pickaxeDurability[src] or pickaxeDurability[src] <= 0 then
-            pickaxeDurability[src] = maxDurability
+        if Config.PickaxeReplacementItem then
+            Player.Functions.AddItem(Config.PickaxeReplacementItem, 1)
+            local replacementItem = RSGCore.Shared.Items[Config.PickaxeReplacementItem]
+
+            if replacementItem then
+                TriggerClientEvent('inventory:client:ItemBox', src, replacementItem, 'add')
+            end
+        end
+
+        local message = Config.PickaxeBrokenMessage or 'Your pickaxe broke!'
+
+        TriggerClientEvent('ox_lib:notify', src, {
+            title = string.format('%s (%s)', message, formatDurability(0, maxDurability)),
+            type = 'error',
+            duration = 4000
+        })
+    else
+        updatePickaxeMetadata(Player, pickaxe, newDurability, maxDurability)
+
+        TriggerClientEvent('ox_lib:notify', src, {
+            title = formatDurability(newDurability, maxDurability),
+            type = 'inform',
+            duration = 2500
+        })
+    end
+end
+
+local function getRockRewardAmount()
+    local reward = Config.RockRewardAmount or 1
+
+    if type(reward) == 'table' then
+        local minAmount = reward.min or reward[1] or 1
+        local maxAmount = reward.max or reward[2] or minAmount
+
+        if maxAmount < minAmount then
+            maxAmount = minAmount
+        end
+
+        return math.random(minAmount, maxAmount)
+    elseif type(reward) == 'number' then
+        if reward < 1 then
+            return 1
+        end
+
+        return math.floor(reward)
+    end
+
+    return 1
+end
+
+local function selectGemReward()
+    local washing = Config.Washing
+
+    if not washing or not washing.gems or #washing.gems == 0 then
+        return nil
+    end
+
+    local totalWeight = 0
+
+    for _, gem in ipairs(washing.gems) do
+        local weight = tonumber(gem.chance) or 0
+
+        if weight > 0 then
+            totalWeight = totalWeight + weight
         end
     end
 
-    local function handlePickaxeDurability(src)
-        local maxDurability = getPickaxeMaxDurability()
+    if totalWeight <= 0 then
+        return washing.gems[math.random(1, #washing.gems)]
+    end
 
-        if maxDurability <= 0 then
-            return
+    local roll = math.random(totalWeight)
+    local cumulative = 0
+
+    for _, gem in ipairs(washing.gems) do
+        local weight = tonumber(gem.chance) or 0
+
+        if weight > 0 then
+            cumulative = cumulative + weight
+
+            if roll <= cumulative then
+                return gem
+            end
         end
+    end
 
-        local Player = RSGCore.Functions.GetPlayer(src)
+    return washing.gems[#washing.gems]
+end
 
-        if not Player then
-            return
+RSGCore.Functions.CreateUseableItem(Config.Pickaxe, function(source)
+    ensurePickaxeDurability(source)
+    TriggerClientEvent('jc-mining:client:StartMining', source)
+end)
+
+if Config.Washing and Config.Washing.item then
+    RSGCore.Functions.CreateUseableItem(Config.Washing.item, function(source)
+        TriggerClientEvent('jc-mining:client:StartWashing', source)
+    end)
+end
+
+RegisterNetEvent('jc-mining:server:washShinyOre', function()
+    local src = source
+    local washing = Config.Washing
+
+    if not washing or not washing.item then
+        return
+    end
+
+    local Player = RSGCore.Functions.GetPlayer(src)
+
+    if not Player then
+        return
+    end
+
+    local shinyItem = Player.Functions.GetItemByName(washing.item)
+
+    if not shinyItem or not Player.Functions.RemoveItem(washing.item, 1, shinyItem.slot) then
+        TriggerClientEvent('ox_lib:notify', src, {
+            title = 'Nie masz zabrudzonego kamienia.',
+            type = 'error',
+            duration = 3000
+        })
+        return
+    end
+
+    local shinyInfo = RSGCore.Shared.Items[washing.item]
+
+    if shinyInfo then
+        TriggerClientEvent('inventory:client:ItemBox', src, shinyInfo, 'remove')
+    end
+
+    local gemReward = selectGemReward()
+
+    if not gemReward or not gemReward.item then
+        TriggerClientEvent('ox_lib:notify', src, {
+            title = 'Nie znaleziono żadnych cennych surowców.',
+            type = 'error',
+            duration = 3000
+        })
+        return
+    end
+
+    Player.Functions.AddItem(gemReward.item, 1, false, gemReward.metadata)
+
+    local gemInfo = RSGCore.Shared.Items[gemReward.item]
+
+    if gemInfo then
+        TriggerClientEvent('inventory:client:ItemBox', src, gemInfo, 'add')
+    end
+
+    TriggerClientEvent('ox_lib:notify', src, {
+        title = string.format('Otrzymano: %s', gemInfo and gemInfo.label or gemReward.item),
+        type = 'success',
+        duration = 3500
+    })
+end)
+
+RegisterNetEvent('jc-mining:server:giveitems', function()
+    local src = source
+    local Player = RSGCore.Functions.GetPlayer(src)
+
+    if not Player then
+        return
+    end
+
+    local rockItem = Config.RockItem or 'rock'
+    local rockAmount = getRockRewardAmount()
+
+    if rockAmount > 0 then
+        Player.Functions.AddItem(rockItem, rockAmount)
+
+        local itemInfo = RSGCore.Shared.Items[rockItem]
+
+        if itemInfo then
+            TriggerClientEvent('inventory:client:ItemBox', src, itemInfo, 'add')
         end
+    end
 
-        local usesLeft = pickaxeDurability[src] or maxDurability
-        usesLeft = usesLeft - 1
+    if Config.ShinyOre and Config.ShinyOre.item and Config.ShinyOre.chancePerHit and Config.ShinyOre.chancePerHit > 0 then
+        if math.random(1, Config.ShinyOre.chancePerHit) == 1 then
+            Player.Functions.AddItem(Config.ShinyOre.item, 1, false, Config.ShinyOre.metadata)
+
+            local shinyInfo = RSGCore.Shared.Items[Config.ShinyOre.item]
+
+            if shinyInfo then
+                TriggerClientEvent('inventory:client:ItemBox', src, shinyInfo, 'add')
+            end
+
+            if Config.ShinyOre.foundMessage then
+                TriggerClientEvent('ox_lib:notify', src, {
+                    title = Config.ShinyOre.foundMessage,
+                    type = 'success',
+                    duration = 3500
+                })
+            end
+        end
+    end
+
+    handlePickaxeDurability(src)
+end)
+
+RegisterNetEvent('jc-mining:server:DrillIce', function(netId)
+    local src = source
+
+    if not netId or not Config.IceDrill or not Config.IceDrill.enabled then
+        TriggerClientEvent('jc-mining:client:IceDrillFailed', src, Config.IceDrill and Config.IceDrill.brokenMessage or 'The drill is not operational.')
+        return
+    end
+
+    local Player = RSGCore.Functions.GetPlayer(src)
+
+    if not Player then
+        return
+    end
+
+    local rewardItem = Config.IceDrill.rewardItem
+
+    if not rewardItem then
+        TriggerClientEvent('jc-mining:client:IceDrillFailed', src, 'No reward configured for the drill.')
+        return
+    end
+
+    local maxDurability = Config.IceDrill.durability or 0
+    local usesLeft
+
+    if maxDurability > 0 then
+        usesLeft = drillDurability[netId] or maxDurability
 
         if usesLeft <= 0 then
-            pickaxeDurability[src] = nil
+            TriggerClientEvent('jc-mining:client:IceDrillFailed', src, Config.IceDrill.brokenMessage or 'The drill has been depleted and needs repairs.')
+            return
+        end
 
-            if Player.Functions.RemoveItem(Config.Pickaxe, 1) then
-                local pickaxeItem = RSGCore.Shared.Items[Config.Pickaxe]
+        local loss = Config.IceDrill.durabilityLoss or 1
+        usesLeft = usesLeft - loss
+        if usesLeft < 0 then
+            usesLeft = 0
+        end
+        drillDurability[netId] = usesLeft
+    end
 
-                if pickaxeItem then
-                    TriggerClientEvent('inventory:client:ItemBox', src, pickaxeItem, 'remove')
-                end
-            end
+    local rewardAmount = Config.IceDrill.rewardAmount or 1
+    local amount = 1
 
-            if Config.PickaxeReplacementItem then
-                Player.Functions.AddItem(Config.PickaxeReplacementItem, 1)
-                local replacementItem = RSGCore.Shared.Items[Config.PickaxeReplacementItem]
+    if type(rewardAmount) == 'table' then
+        local minAmount = rewardAmount.min or rewardAmount[1] or 1
+        local maxAmount = rewardAmount.max or rewardAmount[2] or minAmount
 
-                if replacementItem then
-                    TriggerClientEvent('inventory:client:ItemBox', src, replacementItem, 'add')
-                end
-            end
+        if maxAmount < minAmount then
+            maxAmount = minAmount
+        end
 
-            TriggerClientEvent('ox_lib:notify', src, {
-                title = Config.PickaxeBrokenMessage or 'Your pickaxe broke!',
-                type = 'error',
-                duration = 3000
-            })
-        else
-            pickaxeDurability[src] = usesLeft
+        amount = math.random(minAmount, maxAmount)
+    elseif type(rewardAmount) == 'number' then
+        amount = math.max(1, math.floor(rewardAmount))
+    end
+
+    if amount > 0 then
+        Player.Functions.AddItem(rewardItem, amount)
+        local rewardInfo = RSGCore.Shared.Items[rewardItem]
+
+        if rewardInfo then
+            TriggerClientEvent('inventory:client:ItemBox', src, rewardInfo, 'add')
         end
     end
 
-    local function getIceRewardAmount()
-        local configAmount = Config.IceDrill and Config.IceDrill.rewardAmount
-
-        if type(configAmount) == 'table' then
-            local minAmount = configAmount.min or configAmount[1] or 1
-            local maxAmount = configAmount.max or configAmount[2] or minAmount
-
-            if maxAmount < minAmount then
-                maxAmount = minAmount
-            end
-
-            return math.random(minAmount, maxAmount)
-        elseif type(configAmount) == 'number' then
-            if configAmount < 1 then
-                return 1
-            end
-
-            return math.floor(configAmount)
-        end
-
-        return 1
-    end
-
-    RSGCore.Functions.CreateUseableItem(Config.CommonItems, function(source, item)
-        local src = source
-        TriggerClientEvent('jc-mining:client:StartWashing', src)
-    end)
-
-    RSGCore.Functions.CreateUseableItem(Config.Pickaxe, function(source, item)
-        local src = source
-        ensurePickaxeDurability(src)
-        TriggerClientEvent('jc-mining:client:StartMining', src)
-    end)
-    
-    RegisterNetEvent('jc-mining:server:washStones', function()
-        local src = source
-        local Player = RSGCore.Functions.GetPlayer(src)
-        local item = Config.WashingItems[math.random(1, #Config.WashingItems)]
-        local chance = math.random(1, 100)
-
-        Player.Functions.RemoveItem(Config.CommonItems, 1)
-        TriggerClientEvent('inventory:client:ItemBox', src, RSGCore.Shared.Items[item], 'remove')
-    
-        if chance <= 15 then
-            Player.Functions.AddItem(Config.GoldItems, 1)
-            TriggerClientEvent('inventory:client:ItemBox', src, RSGCore.Shared.Items[Config.GoldItems], 'add')
-            return
-        end
-    
-        Player.Functions.AddItem(item, 1)
-        TriggerClientEvent('inventory:client:ItemBox', src, RSGCore.Shared.Items[item], 'add')     
-    end)
-    
-    RegisterNetEvent('jc-mining:server:giveitems', function(mineType)
-        local src = source
-        local Player = RSGCore.Functions.GetPlayer(src)
-
-        if not Player then
-            return
-        end
-
-        local chance = math.random(1, 100)
-
-        if mineType == 'common' then
-            if chance <= Config.CommonChance then
-                local amount = math.random(2, 6)
-                Player.Functions.AddItem(Config.CommonItems, amount)
-
-                local itemInfo = RSGCore.Shared.Items[Config.CommonItems]
-
-                if itemInfo then
-                    TriggerClientEvent('inventory:client:ItemBox', src, itemInfo, 'add')
-                end
-            else
-                TriggerClientEvent('ox_lib:notify', src, { title = 'You didn\'t get anything!', type = 'error', duration = 3000 })
-            end
-        elseif mineType == 'rare' then
-            if chance <= Config.RareChance then
-                local item = Config.RareItems[math.random(1, #Config.RareItems)]
-                Player.Functions.AddItem(item, math.random(1, 3))
-
-                local itemInfo = RSGCore.Shared.Items[item]
-
-                if itemInfo then
-                    TriggerClientEvent('inventory:client:ItemBox', src, itemInfo, 'add')
-                end
-            else
-                TriggerClientEvent('ox_lib:notify', src, { title = 'You didn\'t get anything!', type = 'error', duration = 3000 })
-            end
-        elseif mineType == 'gems' then
-            if chance <= Config.GemsChance then
-                local item = Config.GemItems[math.random(1, #Config.GemItems)]
-                Player.Functions.AddItem(item, math.random(1, 3))
-
-                local itemInfo = RSGCore.Shared.Items[item]
-
-                if itemInfo then
-                    TriggerClientEvent('inventory:client:ItemBox', src, itemInfo, 'add')
-                end
-            else
-                TriggerClientEvent('ox_lib:notify', src, { title = 'You didn\'t get anything!', type = 'error', duration = 3000 })
-            end
-        elseif mineType == 'gold' then
-            if chance <= Config.GoldChance then
-                local amount = math.random(1, 5)
-                Player.Functions.AddItem(Config.GoldItems, amount)
-
-                local itemInfo = RSGCore.Shared.Items[Config.GoldItems]
-
-                if itemInfo then
-                    TriggerClientEvent('inventory:client:ItemBox', src, itemInfo, 'add')
-                end
-            else
-                TriggerClientEvent('ox_lib:notify', src, { title = 'You didn\'t get anything!', type = 'error', duration = 3000 })
-            end
-        end
-
-        handlePickaxeDurability(src)
-    end)
-
-    RegisterNetEvent('jc-mining:server:DrillIce', function(netId)
-        local src = source
-        local Player = RSGCore.Functions.GetPlayer(src)
-
-        if not Player then
-            return
-        end
-
-        if not netId or not Config.IceDrill or not Config.IceDrill.enabled then
-            TriggerClientEvent('jc-mining:client:IceDrillFailed', src, Config.IceDrill and Config.IceDrill.brokenMessage or 'The drill is not operational.')
-            return
-        end
-
-        local rewardItem = Config.IceDrill.rewardItem
-
-        if not rewardItem then
-            TriggerClientEvent('jc-mining:client:IceDrillFailed', src, 'No reward configured for the drill.')
-            return
-        end
-
-        local maxDurability = Config.IceDrill.durability or 0
-        local usesLeft
-
-        if maxDurability > 0 then
-            usesLeft = drillDurability[netId] or maxDurability
-
-            if usesLeft <= 0 then
-                TriggerClientEvent('jc-mining:client:IceDrillFailed', src, Config.IceDrill.brokenMessage or 'The drill has been depleted and needs repairs.')
-                return
-            end
-
-            usesLeft = usesLeft - 1
-            drillDurability[netId] = usesLeft
-        end
-
-        local rewardAmount = getIceRewardAmount()
-
-        if rewardAmount > 0 then
-            Player.Functions.AddItem(rewardItem, rewardAmount)
-            local rewardInfo = RSGCore.Shared.Items[rewardItem]
-
-            if rewardInfo then
-                TriggerClientEvent('inventory:client:ItemBox', src, rewardInfo, 'add')
-            end
-        end
-
-        if maxDurability > 0 and usesLeft and usesLeft <= 0 then
+    if maxDurability > 0 then
+        if usesLeft and usesLeft <= 0 then
             drillDurability[netId] = nil
             TriggerClientEvent('jc-mining:client:IceDrillDepleted', -1, netId)
             TriggerClientEvent('jc-mining:client:IceDrillFailed', src, Config.IceDrill.brokenMessage or 'The drill has been depleted and needs repairs.')
+        else
+            TriggerClientEvent('ox_lib:notify', src, {
+                title = string.format('Wytrzymałość wiertła: %d/%d', math.max(usesLeft or maxDurability, 0), maxDurability),
+                type = 'inform',
+                duration = 2500
+            })
         end
-    end)
+    end
+end)
 
-    AddEventHandler('playerDropped', function()
-        local src = source
-        pickaxeDurability[src] = nil
-    end)
-
-    RegisterNetEvent('RSGCore:Server:OnPlayerUnload', function(playerId)
-        pickaxeDurability[playerId] = nil
-    end)
-
-end


### PR DESCRIPTION
## Summary
- simplify the configuration to RSG-only settings with new rock, shiny ore, washing and drill durability options
- overhaul client interactions to rely on ox_target for drills, enforce water-only washing and play interact-sound audio while drilling
- rebuild server rewards around rock + shiny ore drops, metadata-driven pickaxe durability and weighted gem washing results, plus document the new workflow and audio asset
- remove the packaged ice drill sound so servers can provide their own interact-sound clip while keeping the setup instructions up to date

## Testing
- not run (no automated tests provided)

------
https://chatgpt.com/codex/tasks/task_e_68ca9d8927908329a2b29db12319500c